### PR TITLE
Add FOAG GitHub link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An overview of the current GitHub organisations maintained by the Swiss Confeder
 * https://github.com/armasuissewt
 * https://github.com/bfspoku
 * https://github.com/BLV-OSAV-USAV
+* https://github.com/blw-ofag-ufag
 * https://github.com/cdc-si/
 * https://github.com/dscc-admin-ch
 * https://github.com/eda-admin-ch


### PR DESCRIPTION
Hello,

I'd like to add the Federal Office for Agriculture's official GitHub organization to this list. We have added and will add `publiccode.yml` metadata files to our relevant open source repositories.

Thanks,
Damian