### PR TITLE
Add bbl-dres to federal GitHub organizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An overview of the current GitHub organisations maintained by the Swiss Confeder
 * https://github.com/agroscope-ch
 * https://github.com/alv-ch
 * https://github.com/armasuissewt
+* https://github.com/bbl-dres
 * https://github.com/bfspoku
 * https://github.com/BLV-OSAV-USAV
 * https://github.com/blw-ofag-ufag


### PR DESCRIPTION
Digital Real Estate and Support, Federal Office for Buildings and Logistics (BBL).